### PR TITLE
FI-2617: README and Suite Description Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ base URLs and organizational details must conform to the following:
       - Reviewed quarterly and, as necessary, updated
 
 This test kit is provided as a preview for feedback and is not currently
-intended for certification. A version of these tests will be migrated into a
-future version of the [ONC (g)(10) Standardized API Test
-Kit](https://github.com/onc-healthit/onc-certification-g10-test-kit).
+intended for certification.
 
 While these tests do not specifically verify conformance to [Patient-Access
 Brands](https://build.fhir.org/ig/HL7/smart-app-launch/brands.html) within the

--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ base URLs and organizational details must conform to the following:
         adopted in FHIR v4.0.1: § 170.215(a) for publication
       - Reviewed quarterly and, as necessary, updated
 
-This test kit is provided as a preview for feedback and is not currently
-intended for certification.
-
 While these tests do not specifically verify conformance to [Patient-Access
 Brands](https://build.fhir.org/ig/HL7/smart-app-launch/brands.html) within the
 draft SMART App Launch v2.2.0 standard, systems that implement that standard

--- a/lib/service_base_url_test_kit.rb
+++ b/lib/service_base_url_test_kit.rb
@@ -37,9 +37,7 @@ module ServiceBaseURLTestKit
             adopted in FHIR v4.0.1: § 170.215\(a\) for publication
 
       This test kit is provided as a preview for feedback and is not currently
-      intended for certification. A version of these tests will be migrated into
-      a future version of the [ONC (g)(10) Standardized API Test
-      Kit](https://github.com/onc-healthit/onc-certification-g10-test-kit).
+      intended for certification.
 
       While these tests do not specifically verify conformance to
       [Patient-Access

--- a/lib/service_base_url_test_kit.rb
+++ b/lib/service_base_url_test_kit.rb
@@ -36,9 +36,6 @@ module ServiceBaseURLTestKit
           - Collected into a Bundle resource formatted according to the standard
             adopted in FHIR v4.0.1: § 170.215\(a\) for publication
 
-      This test kit is provided as a preview for feedback and is not currently
-      intended for certification.
-
       While these tests do not specifically verify conformance to
       [Patient-Access
       Brands](https://build.fhir.org/ig/HL7/smart-app-launch/brands.html) within


### PR DESCRIPTION
# Summary
Update the Service Base URL README and Suite description so that they do not state that the Test Kit may be a part of the future (g)(10) Certification Test Kit. 
