### PR TITLE
FI-2429: Migrate to HL7 validator wrapper

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,2 @@
 JS_HOST=""
-FHIR_RESOURCE_VALIDATOR_URL="http://hl7_validator_service:3500"
 INFERNO_HOST="http://localhost:4567"

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 JS_HOST=""
-VALIDATOR_URL="http://validator_service:4567"
+FHIR_RESOURCE_VALIDATOR_URL="http://hl7_validator_service:3500"
 INFERNO_HOST="http://localhost:4567"

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-VALIDATOR_URL=http://localhost/validatorapi
+FHIR_RESOURCE_VALIDATOR_URL=http://localhost/hl7validatorapi
 REDIS_URL=redis://localhost:6379/0

--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,2 @@
 REDIS_URL=redis://redis:6379/0
-VALIDATOR_URL=http://validator_service:4567
+FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500

--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,2 @@
-VALIDATOR_URL=https://example.com/validatorapi
+FHIR_RESOURCE_VALIDATOR_URL=https://example.com/validatorapi
 ASYNC_JOBS=false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,7 @@ GEM
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    inferno_core (0.4.33)
+    inferno_core (0.4.34)
       activesupport (~> 6.1.7.5)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)
@@ -179,11 +179,11 @@ GEM
       base64
     kramdown (2.4.0)
       rexml
-    method_source (1.0.0)
+    method_source (1.1.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2024.0305)
-    mini_portile2 (2.8.5)
+    mini_portile2 (2.8.6)
     minitest (5.22.3)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -195,14 +195,14 @@ GEM
       mustermann (= 1.1.2)
     netrc (0.11.0)
     nio4r (2.7.1)
-    nokogiri (1.16.3)
+    nokogiri (1.16.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.16.3-arm64-darwin)
+    nokogiri (1.16.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.3-x86_64-darwin)
+    nokogiri (1.16.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.3-x86_64-linux)
+    nokogiri (1.16.4-x86_64-linux)
       racc (~> 1.4)
     oauth2 (1.4.11)
       faraday (>= 0.17.3, < 3.0)
@@ -306,4 +306,4 @@ DEPENDENCIES
   webmock (~> 3.11)
 
 BUNDLED WITH
-   2.3.14
+   2.5.7

--- a/config/nginx.background.conf
+++ b/config/nginx.background.conf
@@ -53,7 +53,37 @@ http {
     # the server will close connections after this time
     keepalive_timeout 600;
 
-    location /validator {
+#    location /validator {
+#      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#      proxy_set_header Host $http_host;
+#      proxy_set_header X-Forwarded-Proto $scheme;
+#      proxy_set_header X-Forwarded-Port $server_port;
+#      proxy_redirect off;
+#      proxy_set_header Connection '';
+#      proxy_http_version 1.1;
+#      chunked_transfer_encoding off;
+#      proxy_buffering off;
+#      proxy_cache off;
+#
+#      proxy_pass http://fhir_validator_app;
+#    }
+#
+#    location /validatorapi/ {
+#      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#      proxy_set_header Host $http_host;
+#      proxy_set_header X-Forwarded-Proto $scheme;
+#      proxy_set_header X-Forwarded-Port $server_port;
+#      proxy_redirect off;
+#      proxy_set_header Connection '';
+#      proxy_http_version 1.1;
+#      chunked_transfer_encoding off;
+#      proxy_buffering off;
+#      proxy_cache off;
+#
+#      proxy_pass http://validator_service:4567/;
+#    }
+
+    location /hl7validatorapi/ {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-Proto $scheme;
@@ -64,23 +94,9 @@ http {
       chunked_transfer_encoding off;
       proxy_buffering off;
       proxy_cache off;
+      proxy_read_timeout 600s;
 
-      proxy_pass http://fhir_validator_app;
-    }
-
-    location /validatorapi/ {
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header Host $http_host;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header X-Forwarded-Port $server_port;
-      proxy_redirect off;
-      proxy_set_header Connection '';
-      proxy_http_version 1.1;
-      chunked_transfer_encoding off;
-      proxy_buffering off;
-      proxy_cache off;
-
-      proxy_pass http://validator_service:4567/;
+      proxy_pass http://hl7_validator_service:3500/;
     }
   }
 }

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -68,7 +68,37 @@ http {
       proxy_pass http://inferno:4567;
     }
 
-    location /validator {
+#    location /validator {
+#      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#      proxy_set_header Host $http_host;
+#      proxy_set_header X-Forwarded-Proto $scheme;
+#      proxy_set_header X-Forwarded-Port $server_port;
+#      proxy_redirect off;
+#      proxy_set_header Connection '';
+#      proxy_http_version 1.1;
+#      chunked_transfer_encoding off;
+#      proxy_buffering off;
+#      proxy_cache off;
+#
+#      proxy_pass http://fhir_validator_app;
+#    }
+#
+#    location /validatorapi/ {
+#      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#      proxy_set_header Host $http_host;
+#      proxy_set_header X-Forwarded-Proto $scheme;
+#      proxy_set_header X-Forwarded-Port $server_port;
+#      proxy_redirect off;
+#      proxy_set_header Connection '';
+#      proxy_http_version 1.1;
+#      chunked_transfer_encoding off;
+#      proxy_buffering off;
+#      proxy_cache off;
+#
+#      proxy_pass http://validator_service:4567/;
+#    }
+
+    location /hl7validatorapi/ {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-Proto $scheme;
@@ -79,23 +109,9 @@ http {
       chunked_transfer_encoding off;
       proxy_buffering off;
       proxy_cache off;
+      proxy_read_timeout 600s;
 
-      proxy_pass http://fhir_validator_app;
-    }
-
-    location /validatorapi/ {
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header Host $http_host;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header X-Forwarded-Port $server_port;
-      proxy_redirect off;
-      proxy_set_header Connection '';
-      proxy_http_version 1.1;
-      chunked_transfer_encoding off;
-      proxy_buffering off;
-      proxy_cache off;
-
-      proxy_pass http://validator_service:4567/;
+      proxy_pass http://hl7_validator_service:3500/;
     }
   }
 }

--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -1,17 +1,28 @@
 version: '3'
 services:
-  validator_service:
-    image: infernocommunity/fhir-validator-service
-    # Update this path to match your directory structure
+  hl7_validator_service:
+    image: infernocommunity/inferno-resource-validator
+    environment:
+      # Defines how long validator sessions last if unused, in minutes:
+      # Negative values mean sessions never expire, 0 means sessions immediately expire
+      SESSION_CACHE_DURATION: -1
     volumes:
       - ./lib/service_base_url_test_kit/igs:/home/igs
-  fhir_validator_app:
-    image: infernocommunity/fhir-validator-app
-    depends_on:
-      - validator_service
-    environment:
-      EXTERNAL_VALIDATOR_URL: http://localhost/validatorapi
-      VALIDATOR_BASE_PATH: /validator
+      # To let the service share your local FHIR package cache,
+      # uncomment the below line
+      # - ~/.fhir:/home/ktor/.fhir
+  # validator_service:
+  #   image: infernocommunity/fhir-validator-service
+  #   # Update this path to match your directory structure
+  #   volumes:
+  #     - ./lib/service_base_url_test_kit/igs:/home/igs
+  # fhir_validator_app:
+  #   image: infernocommunity/fhir-validator-app
+  #   depends_on:
+  #     - validator_service
+  #   environment:
+  #     EXTERNAL_VALIDATOR_URL: http://localhost/validatorapi
+  #     VALIDATOR_BASE_PATH: /validator
   nginx:
     image: nginx
     volumes:
@@ -20,7 +31,8 @@ services:
       - "80:80"
     command: [nginx, '-g', 'daemon off;']
     depends_on:
-      - fhir_validator_app
+      - hl7_validator_service
+      # - fhir_validator_app
   redis:
     image: redis
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     volumes:
       - ./data:/opt/inferno/data
     depends_on:
-      - validator_service
+      # - validator_service
+      - hl7_validator_service
   worker:
     build:
       context: ./
@@ -15,14 +16,18 @@ services:
     command: bundle exec sidekiq -r ./worker.rb
     depends_on:
       - redis
-  validator_service:
+  hl7_validator_service:
     extends:
       file: docker-compose.background.yml
-      service: validator_service
-  fhir_validator_app:
-    extends:
-      file: docker-compose.background.yml
-      service: fhir_validator_app
+      service: hl7_validator_service
+  # validator_service:
+  #   extends:
+  #     file: docker-compose.background.yml
+  #     service: validator_service
+  # fhir_validator_app:
+  #   extends:
+  #     file: docker-compose.background.yml
+  #     service: fhir_validator_app
   nginx:
     extends:
       file: docker-compose.background.yml

--- a/lib/service_base_url_test_kit.rb
+++ b/lib/service_base_url_test_kit.rb
@@ -80,12 +80,17 @@ module ServiceBaseURLTestKit
       route :get, File.join('/examples/', filename), my_bundle_route_handler
     end
 
+    VALIDATION_MESSAGE_FILTERS = [
+      /A resource should have narrative for robust management/,
+      /\A\S+: \S+: URL value '.*' does not resolve/
+    ]
+
     # All FHIR validation requests will use this FHIR validator
-    validator :default do
-      url ENV.fetch('VALIDATOR_URL', 'http://validator_service:4567')
+    fhir_resource_validator :default do
+      url ENV.fetch('FHIR_RESOURCE_VALIDATOR_URL', 'http://hl7_validator_service:3500')
 
       exclude_message do |message|
-        message.message.include?('A resource should have narrative for robust management')
+        VALIDATION_MESSAGE_FILTERS.any? { |filter| filter.match? message.message }
       end
     end
 

--- a/lib/service_base_url_test_kit.rb
+++ b/lib/service_base_url_test_kit.rb
@@ -87,8 +87,6 @@ module ServiceBaseURLTestKit
 
     # All FHIR validation requests will use this FHIR validator
     fhir_resource_validator :default do
-      url ENV.fetch('FHIR_RESOURCE_VALIDATOR_URL', 'http://hl7_validator_service:3500')
-
       exclude_message do |message|
         VALIDATION_MESSAGE_FILTERS.any? { |filter| filter.match? message.message }
       end

--- a/spec/service_base_url/service_base_url_spec.rb
+++ b/spec/service_base_url/service_base_url_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
   let(:test_session) { repo_create(:test_session, test_suite_id: 'service_base_url') }
   let(:base_url) { 'http://example.com/fhir' }
   let(:service_base_url_list_url) { 'http://example.com/fhir/bundleEndpointList' }
-  let(:error_outcome) { FHIR::OperationOutcome.new(issue: [{ severity: 'error' }]) }
-
   let(:runnable) { suite }
   let(:validator_url) { runnable.find_validator(:default).url }
   
@@ -14,34 +12,42 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
       service_base_url_list_url:
     }
   end
-  let(:operation_outcome_success) do
-    FHIR::OperationOutcome.new(
-      issue: [
-        {
-          severity: 'information',
-          code: 'informational',
-          details: {
-            text: 'All OK'
-          }
-        }
-      ]
-    )
+  let(:validator_response_success) do
+    {
+      outcomes: [ {
+        fileInfo: {
+          fileName: "000.json",
+          fileContent: "{ \"resourceType\": \"Bundle\" }",
+          fileType: "json"
+        },
+        issues: []
+      } ],
+      sessionId: "4d9d2dc3-5df1-461f-a4d6-bfc2788a1933"
+    }
   end
-  let(:operation_outcome_failure) do
-    FHIR::OperationOutcome.new(
-      issue: [
-        {
-          severity: 'error',
-          code: 'required',
-          details: {
-            text: 'Bundle.type: minimum required = 1, but only found 0 (from http://hl7.org/fhir/StructureDefinition/Bundle|4.0.1)'
-          },
-          expression: [
-            'Bundle'
-          ]
-        }
-      ]
-    )
+  let(:validator_response_failure) do
+    {
+      outcomes: [ {
+        fileInfo: {
+          fileName: "000.json",
+          fileContent: "{ \"resourceType\": \"Bundle\" }",
+          fileType: "json"
+        },
+        issues: [{
+          source: "InstanceValidator",
+          line: 1,
+          col: 29,
+          location: "Bundle",
+          message: "Bundle.type: minimum required = 1, but only found 0 (from http://hl7.org/fhir/StructureDefinition/Bundle|4.0.1)",
+          messageId: "Validation_VAL_Profile_Minimum",
+          type: "STRUCTURE",
+          level: "ERROR",
+          display: "ERROR: Bundle: Bundle.type: minimum required = 1, but only found 0 (from http://hl7.org/fhir/StructureDefinition/Bundle|4.0.1)",
+          error: true
+        }]
+      } ],
+      sessionId: "b97dfb7c-f7c3-4980-81c3-8adc0024e75b"
+    }
   end
 
   def run(runnable, inputs = {})
@@ -75,7 +81,7 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
 
       validation_request = stub_request(:post, "#{validator_url}/validate")
         .with(query: hash_including({}))
-        .to_return(status: 200, body: operation_outcome_success.to_json)
+        .to_return(status: 200, body: validator_response_success.to_json)
 
       result = run(test, input)
 
@@ -98,7 +104,7 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
       # validator returns a error operation outcome
       validation_request = stub_request(:post, "#{validator_url}/validate")
         .with(query: hash_including({}))
-        .to_return(status: 200, body: operation_outcome_failure.to_json)
+        .to_return(status: 200, body: validator_response_failure.to_json)
 
       result = run(test, input)
 
@@ -123,7 +129,7 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
 
       validation_request = stub_request(:post, "#{validator_url}/validate")
         .with(query: hash_including({}))
-        .to_return(status: 200, body: operation_outcome_success.to_json)
+        .to_return(status: 200, body: validator_response_success.to_json)
 
       result = run(test, input)
 
@@ -144,7 +150,7 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
 
       validation_request = stub_request(:post, "#{validator_url}/validate")
         .with(query: hash_including({}))
-        .to_return(status: 200, body: operation_outcome_success.to_json)
+        .to_return(status: 200, body: validator_response_success.to_json)
 
       result = run(test, input)
 
@@ -187,7 +193,7 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
 
       validation_request = stub_request(:post, "#{validator_url}/validate")
         .with(query: hash_including({}))
-        .to_return(status: 200, body: operation_outcome_success.to_json)
+        .to_return(status: 200, body: validator_response_success.to_json)
 
       result = run(test, input)
 
@@ -209,7 +215,7 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
 
       validation_request = stub_request(:post, "#{validator_url}/validate")
         .with(query: hash_including({}))
-        .to_return(status: 200, body: operation_outcome_success.to_json)
+        .to_return(status: 200, body: validator_response_success.to_json)
 
       result = run(test, input)
 


### PR DESCRIPTION
# Summary
Migrate to HL7 Validator wrapper. Notes:
- As with previous test kits, left the old validator items commented out in case somebody wants to run the UI
- Bumped inferno_core
- Remove the `url` field from the validator definition block since we are standardizing on just the default `FHIR_RESOURCE_VALIDATOR_URL` env var now

# Testing Guidance
Running the entire suite in Ruby with the provided preset should work fine. Theoretically everything should work fine in Docker too but I struggled getting the network connections to work. Running only the "1.2 Validate Service Base URL List" test allows you to paste in the Bundle and run the 2 tests that actually invoke the validator.