### PR TITLE
Adding uniq method to test 1.2.02 to remove testing the same endpoint…

### DIFF
--- a/lib/service_base_url_test_kit/service_base_url_validate_group.rb
+++ b/lib/service_base_url_test_kit/service_base_url_validate_group.rb
@@ -131,6 +131,7 @@ module ServiceBaseURLTestKit
         .map(&:resource)
         .select { |resource| resource.resourceType == 'Endpoint' }
         .map(&:address)
+        .uniq
         .each do |address|
           assert_valid_http_uri(address) 
 


### PR DESCRIPTION
# Summary
Update test 1.2.02 to remove duplicate Endpoint URLs to optimize and speed up tests. There are cases where athenahealth has the same FHIR Service Base URL for different organizations and making duplicate /metadata requests to these slows down the performance of the test kit.