### PR TITLE
FI-2942 Update to final rule and conditions of maintenance requirement language.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ provide feedback on these tests by reporting an issue in
 or by reaching out to the team on the [Inferno FHIR Zulip
 channel](https://chat.fhir.org/#narrow/stream/179309-inferno).
 
-Relevant requirements from the Conditions of [Maintenance of Certification -
+Relevant requirements from the [Conditions of Maintenance of Certification -
 Application programming interfaces](https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-D/part-170/subpart-D/section-170.404#p-170.404(b)(2)):
 
 > Service Base URL publication:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Service Base URL Test Kit
 
-The **Service Base URL Test Kit** provides a set of tests that verifies
+The **Service Base URL Test Kit** provides a set of tests that verify
 conformance of Service Base URL publications to data format requirements as
 described in [Conditions of Maintenance of Certification - Application
 programming

--- a/README.md
+++ b/README.md
@@ -1,54 +1,60 @@
 # Service Base URL Test Kit
 
+The **Service Base URL Test Kit** provides a set of tests that verifies
+conformance of Service Base URL publications to data format requirements as
+described in [Conditions of Maintenance of Certification - Application
+programming
+interfaces](https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-D/part-170/subpart-D/section-170.404#p-170.404(b)(2))
+and the [ONC HTI-1 Final
+Rule](https://www.healthit.gov/topic/laws-regulation-and-policy/health-data-technology-and-interoperability-certification-program).
+Please review the [Application Programming Interfaces Certification Companion
+Guide](https://www.healthit.gov/condition-ccg/application-programming-interfaces)
+for additional guidance.
 
-The **Service Base URL Test Kit** is a testing tool that provides a set of tests
-to validate conformance to the
-[HTI-1](https://www.healthit.gov/topic/laws-regulation-and-policy/health-data-technology-and-interoperability-certification-program)
-[rule](https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-D/part-170/subpart-D/section-170.404#p-170.404(b)(2))
-from the API Condition and Maintenance of Certification to include the
-requirement for Certified API Developers with patient-facing apps to publish
-their service base URLs in [a specified
-format](https://www.federalregister.gov/d/2023-07229/p-2342).
-
-This HTI-1 rule requires that a Certified API developer must publish, at no
-charge, the service base URLs and related organizational details that can be
-used by patients to access their electronic health information. These service
-base URLs and organizational details must conform to the following:
-  - Service based URLs must be publicly published in Endpoint resource format
-    according to the standard adopted in § 170.215(a) - FHIR 4.0.1 release 
-  - Organization details for each service base URL must be publicly published in
-    Organization resource format according to the standard adopted in
-    §170.215(a) - FHIR 4.0.1 release 
-  - Each Organization resource must contain:
-    - A reference in the Organization.endpoint element, to the Endpoint
-      resources containing service base URLs managed by this organization
-    - The organization's name, location, and provider identifier 
-    - Endpoint and Organization resources must be:
-      - Collected into a Bundle resource formatted according to the standard
-        adopted in FHIR v4.0.1: § 170.215(a) for publication
-      - Reviewed quarterly and, as necessary, updated
-
-While these tests do not specifically verify conformance to [Patient-Access
-Brands](https://build.fhir.org/ig/HL7/smart-app-launch/brands.html) within the
-draft SMART App Launch v2.2.0 standard, systems that implement that standard
-should pass these tests. Please report an issue if there are any problems.
-
-The Service Base URL Test Kit is built using the [Inferno
-Framework](https://inferno-framework.github.io/).  The Inferno Framework is
-designed for reuse and aims to make it easier to build test kits for any
-FHIR-based data exchange.
-
-## Reporting Issues
-
-This is a draft set of tests and may contain errors or issues. Please provide
-feedback on these tests by creating an issue in
+This Test Kit is provided as a tool to help developers identify potential issues
+or problems with the structure of their Service Base URL publication.  Test
+failures do not necessarily indicate non-conformance to the Conditions of
+Maintenance of Certification.  Use of these tests is not required. Please
+provide feedback on these tests by reporting an issue in
 [GitHub](https://github.com/inferno-framework/service-base-url-test-kit/issues),
 or by reaching out to the team on the [Inferno FHIR Zulip
-channel](https://chat.fhir.org/#narrow/stream/179309-inferno). 
+channel](https://chat.fhir.org/#narrow/stream/179309-inferno).
 
-## Instructions
+Relevant requirements from the Conditions of [Maintenance of Certification -
+Application programming interfaces](https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-D/part-170/subpart-D/section-170.404#p-170.404(b)(2)):
 
-- Clone this repo.
+> Service Base URL publication:
+> 
+> For all Health IT Modules certified to § 170.315(g)(10), a Certified API
+> Developer must publish, at no charge, the service base URLs and related
+> organization details that can be used by patients to access their
+> electronic health information, by December 31, 2024. This includes all
+> customers regardless of whether the Health IT Modules certified to §
+> 170.315(g)(10) are centrally managed by the Certified API Developer or
+> locally deployed by an API Information Source. These service base URLs and
+> organization details must conform to the following:
+> 
+>   - Service base URLs must be publicly published in Endpoint resource format
+>     according to the standard adopted in § 170.215(a) (FHIR v4.0.1).
+>   - Organization details for each service base URL must be publicly published in Organization
+>     resource format according to the standard adopted in § 170.215(a) (FHIR v4.0.1). Each
+>     Organization resource must contain: 
+>     - A reference, in the Organization endpoint element, to the Endpoint
+>       resources containing service base URLs managed by this organization.
+>     - The organization’s name, location, and facility identifier.
+>   - Endpoint and Organization resources must be:
+>     - Collected into a Bundle resource formatted according to the standard
+>       adopted in § 170.215(a) (FHIR v4.0.01) for publication; 
+>     - and Reviewed quarterly and, as
+>       necessary, updated.
+
+
+## Local Use Instructions
+
+This Test Kit requires either Docker Desktop or Podman to be run in a local
+desktop environment.
+
+- Clone this repository.
 - Run `setup.sh` in this repo.
 - Run `run.sh` in this repo.
 - Navigate to `http://localhost`. The Service Base URL test suite will be
@@ -59,7 +65,7 @@ Documentation](https://inferno-framework.github.io/inferno-core/getting-started.
 for more information on running Inferno.
 
 ## License
-Copyright 2023 The MITRE Corporation
+Copyright 2024 The MITRE Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License. You may obtain a copy of the

--- a/lib/service_base_url_test_kit.rb
+++ b/lib/service_base_url_test_kit.rb
@@ -7,49 +7,54 @@ module ServiceBaseURLTestKit
     id :service_base_url
     title 'Service Base URL Test Suite'
     description %(
-      This test kit provides a draft set of tests to validate conformance to
-      [HTI-1](https://www.healthit.gov/topic/laws-regulation-and-policy/health-data-technology-and-interoperability-certification-program)
-      [rule](https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-D/part-170/subpart-D/section-170.404#p-170.404(b)(2))
-      from the API Condition and Maintenance of Certification to include the
-      requirement for Certified API Developers with patient-facing apps to
-      publish their service base URLs in [a specified
-      format](https://www.federalregister.gov/d/2023-07229/p-2342).
+      This Test Kit provides a set of tests that verifies conformance of Service
+      Base URL publications to data format requirements as described in
+      [Conditions of Maintenance of Certification - Application programming
+      interfaces](https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-D/part-170/subpart-D/section-170.404#p-170.404(b)(2))
+      and the [ONC HTI-1 Final
+      Rule](https://www.healthit.gov/topic/laws-regulation-and-policy/health-data-technology-and-interoperability-certification-program).
+      Please review the [Application Programming Interfaces Certification Companion
+      Guide](https://www.healthit.gov/condition-ccg/application-programming-interfaces)
+      for additional guidance.
 
-      A Certified API developer must publish, at no charge, the service base
-      URLs and related organizational details that can be used by patients to
-      access their electronic health information. This test kit will test that a
-      server's service base URL list conforms to the following:
-        - Service base URL list is publicly accessible
-        - Service based URLs are published in the Endpoint resource format
-          according to the standard adopted in § 170.215\(a\) - FHIR 4.0.1 release
-        - Organization details for each service base URL are published in the
-          Organization resource format according to the standard adopted in §
-          170.215\(a\) - FHIR 4.0.1 release
-        - Each Endpoint resource must:
-          - Have at least one Organization resource that references it in the Bundle
-        - Each Organization resource must:
-          - Have a populated Organization.endpoint field that contains
-            references to the Endpoint resources containing service base URLs
-            managed by this organization
-          - Contain the organization's name, location, and provider identifier 
-        - Endpoint and Organization resources must be:
-          - Collected into a Bundle resource formatted according to the standard
-            adopted in FHIR v4.0.1: § 170.215\(a\) for publication
-
-      While these tests do not specifically verify conformance to
-      [Patient-Access
-      Brands](https://build.fhir.org/ig/HL7/smart-app-launch/brands.html) within
-      the draft SMART App Launch v2.2.0 standard, systems that implement that
-      standard should pass these tests. Please report an issue if there are any
-      problems.
-
-      The tests within this test kit are available for developers that would
-      like to evaluate their service list against the specified format. This is
-      a draft set of tests and may contain errors or issues. Please provide
-      feedback on these tests by reporting an issue in
+      This Test Kit is provided as a tool to help developers identify potential issues
+      or problems with the structure of their Service Base URL publication.  Test
+      failures do not necessarily indicate non-conformance to the Conditions of
+      Maintenance of Certification.  Use of these tests is not required.  Please
+      provide feedback on these tests by reporting an issue in
       [GitHub](https://github.com/inferno-framework/service-base-url-test-kit/issues),
       or by reaching out to the team on the [Inferno FHIR Zulip
       channel](https://chat.fhir.org/#narrow/stream/179309-inferno).
+
+      Relevant requirements from the Conditions of [Maintenance of Certification -
+      Application programming interfaces](https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-D/part-170/subpart-D/section-170.404#p-170.404(b)(2)):
+
+      Service Base URL publication:
+
+      For all Health IT Modules certified to § 170.315(g)(10), a Certified API
+      Developer must publish, at no charge, the service base URLs and related
+      organization details that can be used by patients to access their
+      electronic health information, by December 31, 2024. This includes all
+      customers regardless of whether the Health IT Modules certified to §
+      170.315(g)(10) are centrally managed by the Certified API Developer or
+      locally deployed by an API Information Source. These service base URLs and
+      organization details must conform to the following:
+      
+       - Service base URLs must be publicly published in Endpoint resource format
+         according to the standard adopted in § 170.215(a) (FHIR v4.0.1).
+       - Organization details for each service base URL must be publicly published in Organization
+         resource format according to the standard adopted in § 170.215(a) (FHIR v4.0.1). Each
+         Organization resource must contain: 
+          - A reference, in the Organization endpoint element, to the Endpoint
+            resources containing service base URLs managed by this organization.
+          - The organization’s name, location, and facility identifier.
+       - Endpoint and Organization resources must be:
+         - Collected into a Bundle resource formatted according to the standard
+            adopted in § 170.215(a) (FHIR v4.0.1) for publication; 
+         - and Reviewed quarterly and, as
+            necessary, updated.
+
+
     )
     version VERSION
 

--- a/lib/service_base_url_test_kit.rb
+++ b/lib/service_base_url_test_kit.rb
@@ -7,7 +7,7 @@ module ServiceBaseURLTestKit
     id :service_base_url
     title 'Service Base URL Test Suite'
     description %(
-      This Test Kit provides a set of tests that verifies conformance of Service
+      This Test Kit provides a set of tests that verify conformance of Service
       Base URL publications to data format requirements as described in
       [Conditions of Maintenance of Certification - Application programming
       interfaces](https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-D/part-170/subpart-D/section-170.404#p-170.404(b)(2))

--- a/lib/service_base_url_test_kit/service_base_url_test_group.rb
+++ b/lib/service_base_url_test_kit/service_base_url_test_group.rb
@@ -6,14 +6,14 @@ module ServiceBaseURLTestKit
     id :service_base_url_test_group
     title 'Retrieve and Validate Service Base URL List'
     description %(    
-    Verify that the developer makes its Service Base URL list publicly available
+    Verify that the developer makes its Service Base URL publication is publicly available
     in the Bundle resource format with valid Endpoint and Organization entries.
     This test group will issue a HTTP GET request against the supplied URL to
     retrieve the developer's Service Base URL list and ensure the list is
     publicly accessible. It will then ensure that the returned service base URL
-    list is in the Bundle resource format containing its service base URLs and
+    publication is in the Bundle resource format containing its service base URLs and
     related organizational details in valid Endpoint and Organization resources
-    that follow the specifications detailed in the HTI-1 rule in the API
+    that follow the specifications detailed in the HTI-1 rule and the API
     Condition and Maintenance of Certification.
 
     For systems that provide the service base URL Bundle at a URL, please run

--- a/lib/service_base_url_test_kit/service_base_url_test_group.rb
+++ b/lib/service_base_url_test_kit/service_base_url_test_group.rb
@@ -6,7 +6,7 @@ module ServiceBaseURLTestKit
     id :service_base_url_test_group
     title 'Retrieve and Validate Service Base URL List'
     description %(    
-    Verify that the developer makes its Service Base URL publication is publicly available
+    Verify that the developer makes its Service Base URL publication publicly available
     in the Bundle resource format with valid Endpoint and Organization entries.
     This test group will issue a HTTP GET request against the supplied URL to
     retrieve the developer's Service Base URL list and ensure the list is

--- a/lib/service_base_url_test_kit/service_base_url_validate_group.rb
+++ b/lib/service_base_url_test_kit/service_base_url_validate_group.rb
@@ -3,10 +3,10 @@ module ServiceBaseURLTestKit
     id :service_base_url_validate_list
     title 'Validate Service Base URL List'
     description %(
-      These tests ensure that the developer's Service Base URL list is in the
-      Bundle resource format, with its service base URLs and organizational
+      These tests ensure that the developer's Service Base URL publication is in
+      the Bundle resource format, with its service base URLs and organizational
       details contained in valid Endpoint and Organization entries that follow
-      the specifications detailed in the HTI-1 rule in the API Condition and
+      the specifications detailed in the HTI-1 rule and the API Condition and
       Maintenance of Certification.
     )
     run_as_group
@@ -157,7 +157,7 @@ module ServiceBaseURLTestKit
           - Contain must have elements including:
             - active
             - name
-          - Include the organization's name, location, and provider identifier
+          - Include the organization's name, location, and facility identifier
           - Use the endpoint field to reference Endpoints associated with the Organization:
             - Must reference only Endpoint resources in the endpoint field
             - Must reference at least one Endpoint resource in the endpoint field


### PR DESCRIPTION
# Summary

This updates language and links to be consistent with the final HTI-1 rule.  I removed references to User Access Links for now, as I'm unsure how to reference those properly.  Technically, there is one inconsistency between User Access Links and these tests that has been found (regarding sub-organization and how they reference Endpoints).

# Testing Guidance

Please review the language updates closely for grammar, and that links appear to point to the final rule and final versions of the conditions of maintenance of certification.  Run the test kit and make sure that the formatting appears correct in the suite display.

Once approved, we will need to also update the Test Kit Display page on ONC's hosted platform: https://inferno.healthit.gov/test-kits/service-base-url/  (we should do that alongside a new release of this gem).