### PR TITLE
FI-2945: Refactor Service Base URL Tests

### DIFF
--- a/config/presets/local_host_endpoint_list_preset.json.erb
+++ b/config/presets/local_host_endpoint_list_preset.json.erb
@@ -4,9 +4,9 @@
   "test_suite_id": "service_base_url",
   "inputs": [
     {
-      "name": "service_base_url_list_url",
+      "name": "service_base_url_publication_url",
       "value": "<%= Inferno::Application['base_url'] %>/custom/service_base_url/examples/testBundleValid.json",
-      "title": "Service Base URL List URL",
+      "title": "Service Base URL Publication URL",
       "type": "text"
     }
   ]

--- a/lib/service_base_url_test_kit.rb
+++ b/lib/service_base_url_test_kit.rb
@@ -58,6 +58,14 @@ module ServiceBaseURLTestKit
     )
     version VERSION
 
+    input_instructions <<~INSTRUCTIONS
+      For systems that make their Service Base URL Bundle available at a public endpoint, please input
+      the Service Base URL Publication URL to retreive the Bundle from there in order to perform validation.
+
+      For systems that do not have a Service Base URL Bundle served at a public endpoint, testers can validate by
+      providing the Service Base URL Publication Bundle as an input.
+    INSTRUCTIONS
+
     links [
       {
         label: 'Report Issue',

--- a/lib/service_base_url_test_kit.rb
+++ b/lib/service_base_url_test_kit.rb
@@ -39,18 +39,18 @@ module ServiceBaseURLTestKit
       170.315(g)(10) are centrally managed by the Certified API Developer or
       locally deployed by an API Information Source. These service base URLs and
       organization details must conform to the following:
-      
+
        - Service base URLs must be publicly published in Endpoint resource format
          according to the standard adopted in § 170.215(a) (FHIR v4.0.1).
        - Organization details for each service base URL must be publicly published in Organization
          resource format according to the standard adopted in § 170.215(a) (FHIR v4.0.1). Each
-         Organization resource must contain: 
+         Organization resource must contain:
           - A reference, in the Organization endpoint element, to the Endpoint
             resources containing service base URLs managed by this organization.
-          - The organization’s name, location, and facility identifier.
+          - The organization's name, location, and facility identifier.
        - Endpoint and Organization resources must be:
          - Collected into a Bundle resource formatted according to the standard
-            adopted in § 170.215(a) (FHIR v4.0.1) for publication; 
+            adopted in § 170.215(a) (FHIR v4.0.1) for publication;
          - and Reviewed quarterly and, as
             necessary, updated.
 
@@ -76,11 +76,9 @@ module ServiceBaseURLTestKit
         my_bundle = JSON.parse(erb_template.result).to_json
         filename = filename.delete_suffix('.erb')
       end
-      if filename.include?("CapabilityStatement")
-        filename = filename.delete_suffix('.json') + "/metadata"
-      end
+      filename = "#{filename.delete_suffix('.json')}/metadata" if filename.include?('CapabilityStatement')
       my_bundle_route_handler = proc { [200, { 'Content-Type' => 'application/json' }, [my_bundle]] }
-      
+
       # Serve a JSON file at INFERNO_PATH/custom/service_base_url/examples/filename
       route :get, File.join('/examples/', filename), my_bundle_route_handler
     end

--- a/lib/service_base_url_test_kit/service_base_url_retrieve_group.rb
+++ b/lib/service_base_url_test_kit/service_base_url_retrieve_group.rb
@@ -1,28 +1,28 @@
 module ServiceBaseURLTestKit
   class ServiceBaseURLEndpointQueryGroup < Inferno::TestGroup
     id :service_base_url_retrieve_list
-    title 'Retrieve Service Base URL List'
+    title 'Retrieve Service Base URL Publication'
     description %(
-      A developer's Service Base URL list must be publicly available.  This test
+      A developer's Service Base URL publication must be publicly available.  This test
       issues a HTTP GET request against the supplied URL and expects to receive
-      the service base url list at this location.
+      the service base url publication at this location.
     )
     run_as_group
 
     http_client do
-      url :service_base_url_list_url
+      url :service_base_url_publication_url
       headers Accept: 'application/json, application/fhir+json'
     end
 
     test do
       id :service_base_url_retrieve_list_test
-      title 'Server returns publicly accessible Service Base URL List'
+      title 'Server returns publicly accessible Service Base URL Publication'
       description %(
         Verify that the developer's list of Service Base URLs can be publicly
         accessed at the supplied URL location.
       )
 
-      input :service_base_url_list_url,
+      input :service_base_url_publication_url,
             optional: true
 
       output :bundle_response
@@ -30,7 +30,7 @@ module ServiceBaseURLTestKit
       makes_request :bundle_request
 
       run do
-        omit_if service_base_url_list_url.blank?, 'URL for Service Base URL List not Inputted.'
+        omit_if service_base_url_publication_url.blank?, 'URL for Service Base URL Publication not Inputted.'
 
         get(tags: ['service_base_url_bundle'])
         assert_response_status(200)

--- a/lib/service_base_url_test_kit/service_base_url_retrieve_group.rb
+++ b/lib/service_base_url_test_kit/service_base_url_retrieve_group.rb
@@ -9,13 +9,9 @@ module ServiceBaseURLTestKit
     )
     run_as_group
 
-    input :service_base_url_list_url,
-      title: 'Service Base URL List URL',
-      description: 'The URL to the developer\'s public Service Base URL List'
-
     http_client do
       url :service_base_url_list_url
-      headers 'Accept': 'application/json, application/fhir+json'
+      headers Accept: 'application/json, application/fhir+json'
     end
 
     test do
@@ -26,15 +22,19 @@ module ServiceBaseURLTestKit
         accessed at the supplied URL location.
       )
 
+      input :service_base_url_list_url,
+            optional: true
+
       output :bundle_response
 
       makes_request :bundle_request
 
       run do
-        get
+        omit_if service_base_url_list_url.blank?, 'URL for Service Base URL List not Inputted.'
+
+        get(tags: ['service_base_url_bundle'])
         assert_response_status(200)
-        output bundle_response: resource.to_json
-      end      
+      end
     end
   end
 end

--- a/lib/service_base_url_test_kit/service_base_url_test_group.rb
+++ b/lib/service_base_url_test_kit/service_base_url_test_group.rb
@@ -4,12 +4,12 @@ require_relative 'service_base_url_retrieve_group'
 module ServiceBaseURLTestKit
   class ServiceBaseURLGroup < Inferno::TestGroup
     id :service_base_url_test_group
-    title 'Retrieve and Validate Service Base URL List'
+    title 'Validate Service Base URL Publication'
     description %(
     Verify that the developer makes its Service Base URL publication publicly available
     in the Bundle resource format with valid Endpoint and Organization entries.
     This test group will issue a HTTP GET request against the supplied URL to
-    retrieve the developer's Service Base URL list and ensure the list is
+    retrieve the developer's Service Base URL publication and ensure the list is
     publicly accessible. It will then ensure that the returned service base URL
     publication is in the Bundle resource format containing its service base URLs and
     related organizational details in valid Endpoint and Organization resources
@@ -17,26 +17,37 @@ module ServiceBaseURLTestKit
     Condition and Maintenance of Certification.
 
     For systems that provide the service base URL Bundle at a URL, please run
-    all tests within this group.  While it is the expectation of the
+    this test with the Service Base URL Publication URL input populated. While it is the expectation of the
     specification for the service base URL Bundle to be served at a
     public-facing endpoint, testers can validate a Service Base URL Bundle not
-    served at a public endpoint by running Test 1.2: Validate Service Base URL
-    List validation individually with the Service Base URL List Bundle input populated and the Service Base URL List
-    URL input is left blank.
+    served at a public endpoint by running these tests with the Service Base URL Publication Bundle input populated
+    and the Service Base URL Publication URL input left blank.
     )
 
-    input :service_base_url_list_url,
-          title: 'Service Base URL List URL',
-          description: %(The URL to the developer's public Service Base URL List. Insert your Service Base URL list URL
-          if you host your Bundle at a public-facing endpoint and want Inferno to retrieve the Bundle from there.),
+    input_instructions <<~INSTRUCTIONS
+      For systems that make their Service Base URL Bundle available at a public endpoint, please input
+      the Service Base URL Publication URL to retreive the Bundle from there in order to perform validation.
+
+      For systems that do not have a Service Base URL Bundle served at a public endpoint, testers can validate by
+      providing the Service Base URL Publication Bundle as an input and leaving the Service Base URL Publication URL
+      input blank.
+    INSTRUCTIONS
+
+    run_as_group
+
+    input :service_base_url_publication_url,
+          title: 'Service Base URL Publication URL',
+          description: %(The URL to the developer's public Service Base URL Publication. Insert your Service Base URL
+          publication URL if you host your Bundle at a public-facing endpoint and want Inferno to retrieve the Bundle
+          from there.),
           optional: true
 
     input :service_base_url_bundle,
-          title: 'Service Base URL List Bundle',
-          description: %(The developer's Service Base URL List in the JSON string format. If this input is populated,
-          Inferno will use the Bundle inserted here to do validation. Insert your Service Base URL List Bundle in the
-          JSON format in this input to validate your list without Inferno needing to access the Bundle via a
-          public-facing endpoint.),
+          title: 'Service Base URL Publication Bundle',
+          description: %(The developer's Service Base URL Publication in the JSON string format. If this input is
+          populated, Inferno will use the Bundle inserted here to do validation. Insert your Service Base URL
+          Publication Bundle in the JSON format in this input to validate your list without Inferno needing to access
+          the Bundle via a public-facing endpoint.),
           type: 'textarea',
           optional: true
 

--- a/lib/service_base_url_test_kit/service_base_url_test_group.rb
+++ b/lib/service_base_url_test_kit/service_base_url_test_group.rb
@@ -5,7 +5,7 @@ module ServiceBaseURLTestKit
   class ServiceBaseURLGroup < Inferno::TestGroup
     id :service_base_url_test_group
     title 'Retrieve and Validate Service Base URL List'
-    description %(    
+    description %(
     Verify that the developer makes its Service Base URL publication publicly available
     in the Bundle resource format with valid Endpoint and Organization entries.
     This test group will issue a HTTP GET request against the supplied URL to
@@ -21,9 +21,25 @@ module ServiceBaseURLTestKit
     specification for the service base URL Bundle to be served at a
     public-facing endpoint, testers can validate a Service Base URL Bundle not
     served at a public endpoint by running Test 1.2: Validate Service Base URL
-    List validation individually.
+    List validation individually with the Service Base URL List Bundle input populated and the Service Base URL List
+    URL input is left blank.
     )
-    
+
+    input :service_base_url_list_url,
+          title: 'Service Base URL List URL',
+          description: %(The URL to the developer's public Service Base URL List. Insert your Service Base URL list URL
+          if you host your Bundle at a public-facing endpoint and want Inferno to retrieve the Bundle from there.),
+          optional: true
+
+    input :service_base_url_bundle,
+          title: 'Service Base URL List Bundle',
+          description: %(The developer's Service Base URL List in the JSON string format. If this input is populated,
+          Inferno will use the Bundle inserted here to do validation. Insert your Service Base URL List Bundle in the
+          JSON format in this input to validate your list without Inferno needing to access the Bundle via a
+          public-facing endpoint.),
+          type: 'textarea',
+          optional: true
+
     group from: :service_base_url_retrieve_list
     group from: :service_base_url_validate_list
   end

--- a/lib/service_base_url_test_kit/service_base_url_validate_group.rb
+++ b/lib/service_base_url_test_kit/service_base_url_validate_group.rb
@@ -1,7 +1,7 @@
 module ServiceBaseURLTestKit
   class ServiceBaseURLBundleTestGroup < Inferno::TestGroup
     id :service_base_url_validate_list
-    title 'Validate Service Base URL List'
+    title 'Validate Service Base URL Publication'
     description %(
       These tests ensure that the developer's Service Base URL publication is in
       the Bundle resource format, with its service base URLs and organizational
@@ -9,10 +9,11 @@ module ServiceBaseURLTestKit
       the specifications detailed in the HTI-1 rule and the API Condition and
       Maintenance of Certification.
 
-      These tests may be run individually, bypassing the first test group, if the Service Base URL List Bundle input
-      is populated and the Service Base URL List URL is left blank (or if it does not successfully return a Service Base
-      URL List Bundle). You may insert your Service Base URL List Bundle in the JSON format in the Service Base URL List
-      Bundle input to validate your list without Inferno needing to retrieve the Bundle via a public-facing endpoint.
+      These tests may be run individually, bypassing the first test group, if the Service Base URL Publication Bundle
+      input is populated and the Service Base URL Publication URL is left blank (or if it does not successfully return
+      a Service Base URL Publication Bundle). You may insert your Service Base URL Publication Bundle in the JSON
+      format in the Service Base URL Publication Bundle input to validate your list without Inferno needing to retrieve
+      the Bundle via a public-facing endpoint.
     )
     run_as_group
 
@@ -41,6 +42,14 @@ module ServiceBaseURLTestKit
         .select { |endpoint_id| endpoint_id_ref.include? endpoint_id }
     end
 
+    def skip_message
+      %(
+        No Service Base URL request was made in the previous test, and no Service Base URL Publication Bundle
+        was provided as input instead. Either provide a Service Base URL Publication URL to retrieve the Bundle via a
+        HTTP GET request, or provide the Bundle as an input.
+      )
+    end
+
     #  Valid BUNDLE TESTS
     test do
       id :service_base_url_valid_bundle
@@ -52,7 +61,7 @@ module ServiceBaseURLTestKit
       run do
         bundle_response = if service_base_url_bundle.blank?
                             load_tagged_requests('service_base_url_bundle')
-                            skip 'No Service Base URL request was made in the previous test.' if requests.length != 1
+                            skip skip_message if requests.length != 1
                             requests.first.response_body
                           else
                             service_base_url_bundle
@@ -75,7 +84,7 @@ module ServiceBaseURLTestKit
     # VALID ENDPOINT TESTS
     test do
       id :service_base_url_valid_endpoints
-      title 'Service Base URL List contains valid Endpoint resources'
+      title 'Service Base URL Publication contains valid Endpoint resources'
       description %(
         Verify that Bundle of Service Base URLs contains Endpoints that are
         valid Endpoint resources according to the format defined in FHIR v4.0.1.
@@ -92,7 +101,7 @@ module ServiceBaseURLTestKit
       run do
         bundle_response = if service_base_url_bundle.blank?
                             load_tagged_requests('service_base_url_bundle')
-                            skip 'No Service Base URL request was made in the previous test.' if requests.length != 1
+                            skip skip_message if requests.length != 1
                             requests.first.response_body
                           else
                             service_base_url_bundle
@@ -138,7 +147,7 @@ module ServiceBaseURLTestKit
       run do
         bundle_response = if service_base_url_bundle.blank?
                             load_tagged_requests('service_base_url_bundle')
-                            skip 'No Service Base URL request was made in the previous test.' if requests.length != 1
+                            skip skip_message if requests.length != 1
                             requests.first.response_body
                           else
                             service_base_url_bundle
@@ -171,7 +180,7 @@ module ServiceBaseURLTestKit
     # ORGANIZATION TESTS
     test do
       id :service_base_url_valid_organizations
-      title 'Service Base URL List contains valid Organization resources'
+      title 'Service Base URL Publication contains valid Organization resources'
       description %(
 
         Verify that Bundle of Service Base URLs contains Organizations that are valid Organization resources according
@@ -191,7 +200,7 @@ module ServiceBaseURLTestKit
       run do
         bundle_response = if service_base_url_bundle.blank?
                             load_tagged_requests('service_base_url_bundle')
-                            skip 'No Service Base URL request was made in the previous test.' if requests.length != 1
+                            skip skip_message if requests.length != 1
                             requests.first.response_body
                           else
                             service_base_url_bundle

--- a/lib/service_base_url_test_kit/service_base_url_validate_group.rb
+++ b/lib/service_base_url_test_kit/service_base_url_validate_group.rb
@@ -160,7 +160,7 @@ module ServiceBaseURLTestKit
           assert_valid_http_uri(address)
 
           address = address.delete_suffix('/')
-          get("#{address}/metadata", client: nil, headers: { Accept: 'application/json, application/fhir+json' })
+          get("#{address}/metadata", client: nil, headers: { Accept: 'application/fhir+json' })
           assert_response_status(200)
           assert resource.present?, 'The content received does not appear to be a valid FHIR resource'
           assert_resource_type(:capability_statement)

--- a/spec/service_base_url/service_base_url_spec.rb
+++ b/spec/service_base_url/service_base_url_spec.rb
@@ -3,13 +3,13 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'service_base_url') }
   let(:base_url) { 'http://example.com/fhir' }
-  let(:service_base_url_list_url) { 'http://example.com/fhir/bundleEndpointList' }
+  let(:service_base_url_publication_url) { 'http://example.com/fhir/bundleEndpointList' }
   let(:runnable) { suite }
   let(:validator_url) { runnable.find_validator(:default).url }
 
   let(:input) do
     {
-      service_base_url_list_url:
+      service_base_url_publication_url:
     }
   end
   let(:validator_response_success) do
@@ -70,7 +70,7 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
     let(:capability_statement) { FHIR.from_contents(File.read('spec/fixtures/CapabilityStatement.json')) }
 
     it 'passes if a valid Bundle was received' do
-      stub_request(:get, service_base_url_list_url)
+      stub_request(:get, service_base_url_publication_url)
         .to_return(status: 200, body: bundle_resource.to_json, headers: {})
 
       uri_template = Addressable::Template.new "#{base_url}/{id}/metadata"
@@ -84,7 +84,7 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
       result = run(test, input)
 
       expect(result.result).to eq('pass'), %(
-          Expected a service base URL list that returns a publicly accessible valid Bundle to pass
+          Expected a service base URL publication that returns a publicly accessible valid Bundle to pass
       )
       expect(capability_statement_request).to have_been_made.times(3)
       expect(validation_request).to have_been_made.times(7)
@@ -108,11 +108,11 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
       expect(validation_request).to have_been_made.times(7)
     end
 
-    it 'skips if no service base URL list URL or Bundle input provided' do
+    it 'skips if no service base URL publication URL or Bundle input provided' do
       result = run(test)
 
       expect(result.result).to eq('skip'), %(
-        Expect tests to skip if no service base URL list URL or service base URL Bundle inputted.
+        Expect tests to skip if no service base URL publication URL or service base URL Bundle inputted.
     )
     end
 
@@ -120,7 +120,7 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
       # Remove a required field from Bundle resource
       bundle_resource.type = ''
 
-      stub_request(:get, service_base_url_list_url)
+      stub_request(:get, service_base_url_publication_url)
         .to_return(status: 200, body: bundle_resource.to_json, headers: {})
 
       uri_template = Addressable::Template.new "#{base_url}/{id}/metadata"
@@ -144,7 +144,7 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
       # change one of the Endpoint addresses to a URL that does not successfully return a capability statement
       bundle_resource.entry[4].resource.address = "#{base_url}/fake/address"
 
-      stub_request(:get, service_base_url_list_url)
+      stub_request(:get, service_base_url_publication_url)
         .to_return(status: 200, body: bundle_resource.to_json, headers: {})
 
       # this endpoint address capability statement endpoint will return a 404
@@ -172,7 +172,7 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
     it 'fails if Bundle contains endpoint that has an invalid URL in the address field' do
       bundle_resource.entry[4].resource.address = 'invalid_url%.com'
 
-      stub_request(:get, service_base_url_list_url)
+      stub_request(:get, service_base_url_publication_url)
         .to_return(status: 200, body: bundle_resource.to_json, headers: {})
 
       uri_template = Addressable::Template.new "#{base_url}/{id}/metadata"
@@ -218,7 +218,7 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
                                      resource: org
                                    ))
 
-      stub_request(:get, service_base_url_list_url)
+      stub_request(:get, service_base_url_publication_url)
         .to_return(status: 200, body: bundle_resource.to_json, headers: {})
 
       uri_template = Addressable::Template.new "#{base_url}/{id}/metadata"
@@ -241,7 +241,7 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
       # Remove the last Organizaition entry so that one Endpoint does not have an Organization resource that references it
       bundle_resource.entry.delete_at(3)
 
-      stub_request(:get, service_base_url_list_url)
+      stub_request(:get, service_base_url_publication_url)
         .to_return(status: 200, body: bundle_resource.to_json, headers: {})
 
       uri_template = Addressable::Template.new "#{base_url}/{id}/metadata"

--- a/spec/service_base_url/service_base_url_spec.rb
+++ b/spec/service_base_url/service_base_url_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
   let(:service_base_url_list_url) { 'http://example.com/fhir/bundleEndpointList' }
   let(:runnable) { suite }
   let(:validator_url) { runnable.find_validator(:default).url }
-  
+
   let(:input) do
     {
       service_base_url_list_url:
@@ -14,39 +14,39 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
   end
   let(:validator_response_success) do
     {
-      outcomes: [ {
+      outcomes: [{
         fileInfo: {
-          fileName: "000.json",
-          fileContent: "{ \"resourceType\": \"Bundle\" }",
-          fileType: "json"
+          fileName: '000.json',
+          fileContent: '{ "resourceType": "Bundle" }',
+          fileType: 'json'
         },
         issues: []
-      } ],
-      sessionId: "4d9d2dc3-5df1-461f-a4d6-bfc2788a1933"
+      }],
+      sessionId: '4d9d2dc3-5df1-461f-a4d6-bfc2788a1933'
     }
   end
   let(:validator_response_failure) do
     {
-      outcomes: [ {
+      outcomes: [{
         fileInfo: {
-          fileName: "000.json",
-          fileContent: "{ \"resourceType\": \"Bundle\" }",
-          fileType: "json"
+          fileName: '000.json',
+          fileContent: '{ "resourceType": "Bundle" }',
+          fileType: 'json'
         },
         issues: [{
-          source: "InstanceValidator",
+          source: 'InstanceValidator',
           line: 1,
           col: 29,
-          location: "Bundle",
-          message: "Bundle.type: minimum required = 1, but only found 0 (from http://hl7.org/fhir/StructureDefinition/Bundle|4.0.1)",
-          messageId: "Validation_VAL_Profile_Minimum",
-          type: "STRUCTURE",
-          level: "ERROR",
-          display: "ERROR: Bundle: Bundle.type: minimum required = 1, but only found 0 (from http://hl7.org/fhir/StructureDefinition/Bundle|4.0.1)",
+          location: 'Bundle',
+          message: 'Bundle.type: minimum required = 1, but only found 0 (from http://hl7.org/fhir/StructureDefinition/Bundle|4.0.1)',
+          messageId: 'Validation_VAL_Profile_Minimum',
+          type: 'STRUCTURE',
+          level: 'ERROR',
+          display: 'ERROR: Bundle: Bundle.type: minimum required = 1, but only found 0 (from http://hl7.org/fhir/StructureDefinition/Bundle|4.0.1)',
           error: true
         }]
-      } ],
-      sessionId: "b97dfb7c-f7c3-4980-81c3-8adc0024e75b"
+      }],
+      sessionId: 'b97dfb7c-f7c3-4980-81c3-8adc0024e75b'
     }
   end
 
@@ -63,18 +63,16 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
     end
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
   end
-  
+
   describe 'Service Base URL Tests' do
     let(:test) { suite }
     let(:bundle_resource) { FHIR.from_contents(File.read('spec/fixtures/testBundleValid.json')) }
     let(:capability_statement) { FHIR.from_contents(File.read('spec/fixtures/CapabilityStatement.json')) }
 
     it 'passes if a valid Bundle was received' do
-      
       stub_request(:get, service_base_url_list_url)
         .to_return(status: 200, body: bundle_resource.to_json, headers: {})
 
-      
       uri_template = Addressable::Template.new "#{base_url}/{id}/metadata"
       capability_statement_request = stub_request(:get, uri_template)
         .to_return(status: 200, body: capability_statement.to_json, headers: {})
@@ -85,18 +83,46 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
 
       result = run(test, input)
 
-      expect(result.result).to eq('pass'), "Expected a service base URL list that returns a publicly accessible valid Bundle resource to pass test."
+      expect(result.result).to eq('pass'), %(
+          Expected a service base URL list that returns a publicly accessible valid Bundle to pass
+      )
       expect(capability_statement_request).to have_been_made.times(3)
+      expect(validation_request).to have_been_made.times(7)
+    end
+
+    it 'passes if a valid Bundle was inputted' do
+      uri_template = Addressable::Template.new "#{base_url}/{id}/metadata"
+      capability_statement_request = stub_request(:get, uri_template)
+        .to_return(status: 200, body: capability_statement.to_json, headers: {})
+
+      validation_request = stub_request(:post, "#{validator_url}/validate")
+        .with(query: hash_including({}))
+        .to_return(status: 200, body: validator_response_success.to_json)
+
+      result = run(test, service_base_url_bundle: bundle_resource.to_json)
+
+      expect(result.result).to eq('pass'), %(
+        Expected a valid inputted service base url Bundle to pass
+    )
+      expect(capability_statement_request).to have_been_made.times(3)
+      expect(validation_request).to have_been_made.times(7)
+    end
+
+    it 'skips if no service base URL list URL or Bundle input provided' do
+      result = run(test)
+
+      expect(result.result).to eq('skip'), %(
+        Expect tests to skip if no service base URL list URL or service base URL Bundle inputted.
+    )
     end
 
     it 'fails if an invalid Bundle was received' do
       # Remove a required field from Bundle resource
-      bundle_resource.type = ""
-      
+      bundle_resource.type = ''
+
       stub_request(:get, service_base_url_list_url)
         .to_return(status: 200, body: bundle_resource.to_json, headers: {})
 
-      
       uri_template = Addressable::Template.new "#{base_url}/{id}/metadata"
       stub_request(:get, uri_template)
         .to_return(status: 200, body: capability_statement.to_json, headers: {})
@@ -108,21 +134,23 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
 
       result = run(test, input)
 
-      expect(result.result).to eq('fail'), "Expected if validation servicer responds with a validation fail or Bundle resource that the test fails."
+      expect(result.result).to eq('fail'), %(
+          Expected if validation service responds with a validation fail or Bundle resource that is invalid.
+      )
+      expect(validation_request).to have_been_made.times(7)
     end
 
     it 'fails if Bundle contains endpoint that do not return a successful capability statement' do
-      
       # change one of the Endpoint addresses to a URL that does not successfully return a capability statement
       bundle_resource.entry[4].resource.address = "#{base_url}/fake/address"
-      
+
       stub_request(:get, service_base_url_list_url)
         .to_return(status: 200, body: bundle_resource.to_json, headers: {})
 
       # this endpoint address capability statement endpoint will return a 404
       capability_statement_request_fail = stub_request(:get, "#{base_url}/fake/address/metadata")
-        .to_return(status: 404, body: "", headers: {})
-     
+        .to_return(status: 404, body: '', headers: {})
+
       uri_template = Addressable::Template.new "#{base_url}/{id}/metadata"
       capability_statement_request_success = stub_request(:get, uri_template)
         .to_return(status: 200, body: capability_statement.to_json, headers: {})
@@ -133,17 +161,20 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
 
       result = run(test, input)
 
-      expect(result.result).to eq('fail'), "Expected test to fail when Bundle contains endpoint that does not return a successful capability statement."
+      expect(result.result).to eq('fail'), %(
+          Expected test to fail when Bundle contains endpoint that does not return a successful 200
+      )
       expect(capability_statement_request_success).to have_been_made.times(2)
+      expect(capability_statement_request_fail).to have_been_made
+      expect(validation_request).to have_been_made.times(7)
     end
 
     it 'fails if Bundle contains endpoint that has an invalid URL in the address field' do
+      bundle_resource.entry[4].resource.address = 'invalid_url%.com'
 
-      bundle_resource.entry[4].resource.address = "invalid_url%.com"
-      
       stub_request(:get, service_base_url_list_url)
         .to_return(status: 200, body: bundle_resource.to_json, headers: {})
-      
+
       uri_template = Addressable::Template.new "#{base_url}/{id}/metadata"
       capability_statement_request = stub_request(:get, uri_template)
         .to_return(status: 200, body: capability_statement.to_json, headers: {})
@@ -154,18 +185,21 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
 
       result = run(test, input)
 
-      expect(result.result).to eq('fail'), "Expected test to fail when Bundle contains endpoint that has an invalid URL in address field."
+      expect(result.result).to eq('fail'), %(
+          Expected test to fail when Bundle contains endpoint that has an invalid URL in address field
+      )
+      expect(capability_statement_request).to have_been_made.times(2)
+      expect(validation_request).to have_been_made.times(7)
     end
 
     it 'fails if Bundle contains an Organization that references a fake Endpoint' do
-      
       # add organization resource to bundle that does not reference an Endpoint contained in the Bundle
       org = FHIR::Organization.new(
         name: 'Test Medical Center 4',
         active: true,
         identifier: [{
           system: 'http://hl7.org/fhir/sid/us-npi',
-          value:'1396251542'
+          value: '1396251542'
         }],
         address: [
           {
@@ -180,13 +214,13 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
       )
 
       bundle_resource.entry.append(FHIR::Bundle::Entry.new(
-        fullUrl: "https://example.com/base/Organization/example-organization-4",
-        resource: org
-      ))
-     
+                                     fullUrl: 'https://example.com/base/Organization/example-organization-4',
+                                     resource: org
+                                   ))
+
       stub_request(:get, service_base_url_list_url)
         .to_return(status: 200, body: bundle_resource.to_json, headers: {})
-     
+
       uri_template = Addressable::Template.new "#{base_url}/{id}/metadata"
       stub_request(:get, uri_template)
         .to_return(status: 200, body: capability_statement.to_json, headers: {})
@@ -197,18 +231,19 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
 
       result = run(test, input)
 
-      expect(result.result).to eq('fail'), "Expected if Organization within the bundle references an Endpoint not in the Bundle, then test will fail."
+      expect(result.result).to eq('fail'), %(
+          Expected if Organization within the bundle references an Endpoint not in the Bundle, then test will fail.
+      )
+      expect(validation_request).to have_been_made.times(8)
     end
 
     it 'fails if Bundle contains an Endpoint that does have an associated Organization reference' do
-      
       # Remove the last Organizaition entry so that one Endpoint does not have an Organization resource that references it
       bundle_resource.entry.delete_at(3)
-      
+
       stub_request(:get, service_base_url_list_url)
         .to_return(status: 200, body: bundle_resource.to_json, headers: {})
 
-      
       uri_template = Addressable::Template.new "#{base_url}/{id}/metadata"
       stub_request(:get, uri_template)
         .to_return(status: 200, body: capability_statement.to_json, headers: {})
@@ -219,7 +254,10 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
 
       result = run(test, input)
 
-      expect(result.result).to eq('fail'), "Expected if Endpoint within bundle does not have an Organization that references it, then test will fail."
+      expect(result.result).to eq('fail'), %(
+          Expected if Endpoint within bundle does not have an Organization that references it, then test will fail.
+      )
+      expect(validation_request).to have_been_made.times(6)
     end
   end
 end


### PR DESCRIPTION
# Summary

Refactor Service Base URL tests so that they now have the following features:
- The tests have two inputs, a Service Base URL list URL and a Service Base URL list Bundle that are both optional
- If the Service Base URL list URL input is not populated, the retrieve service base url test is omitted
- If the Service Base URL list Bundle input is populated, the validation tests will use the inputted Bundle
- Rather than passing the Bundle response via inputs/outputs, the request is now tagged and then loaded in each test that needs to use the test

