### PR TITLE
FI-2947: Allow Some /metadata Requests to Fail

### DIFF
--- a/lib/service_base_url_test_kit/service_base_url_validate_group.rb
+++ b/lib/service_base_url_test_kit/service_base_url_validate_group.rb
@@ -27,6 +27,31 @@ module ServiceBaseURLTestKit
           ),
           optional: true
 
+    input :endpoint_availability_success_rate,
+          title: 'Endpoint Availability Success Rate',
+          description: %(
+            Select an option to choose how many Endpoints have to be available and send back a valid capability
+            statement for the Endpoint validation test to pass.
+          ),
+          type: 'radio',
+          options: {
+            list_options: [
+              {
+                label: 'All',
+                value: 'all'
+              },
+              {
+                label: 'At Least 1',
+                value: 'at_least_1'
+              },
+              {
+                label: 'None',
+                value: 'none'
+              }
+            ]
+          },
+          default: 'all'
+
     # @private
     def find_referenced_org(bundle_resource, endpoint_id)
       bundle_resource
@@ -170,16 +195,40 @@ module ServiceBaseURLTestKit
           )
         end
 
+        one_endpoint_valid = false
+
         endpoint_list.each_with_index do |address, index|
           assert_valid_http_uri(address)
 
-          next if endpoint_availability_limit.present? && endpoint_availability_limit.to_i <= index
+          next if endpoint_availability_success_rate == 'none' ||
+                  (endpoint_availability_limit.present? && endpoint_availability_limit.to_i <= index)
 
           address = address.delete_suffix('/')
           get("#{address}/metadata", client: nil, headers: { Accept: 'application/fhir+json' })
-          assert_response_status(200)
-          assert resource.present?, 'The content received does not appear to be a valid FHIR resource'
-          assert_resource_type(:capability_statement)
+
+          if endpoint_availability_success_rate == 'all'
+            assert_response_status(200)
+            assert resource.present?, 'The content received does not appear to be a valid FHIR resource'
+            assert_resource_type(:capability_statement)
+          else
+            warning do
+              assert_response_status(200)
+              assert resource.present?, 'The content received does not appear to be a valid FHIR resource'
+              assert_resource_type(:capability_statement)
+            end
+
+            if !one_endpoint_valid && response[:status] == 200 && resource.present? &&
+               resource.resourceType == 'CapabilityStatement'
+              one_endpoint_valid = true
+            end
+          end
+        end
+
+        if endpoint_availability_success_rate == 'at_least_1'
+          assert(one_endpoint_valid, %(
+            There were no Endpoints that were available and returned a valid Capability Statement in the Service Base
+            URL Bundle'
+          ))
         end
       end
     end

--- a/spec/service_base_url/service_base_url_spec.rb
+++ b/spec/service_base_url/service_base_url_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
 
   let(:input) do
     {
-      service_base_url_list_url:
+      service_base_url_list_url:,
+      endpoint_availability_success_rate: 'all'
     }
   end
   let(:validator_response_success) do
@@ -99,7 +100,7 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
         .with(query: hash_including({}))
         .to_return(status: 200, body: validator_response_success.to_json)
 
-      result = run(test, service_base_url_bundle: bundle_resource.to_json)
+      result = run(test, service_base_url_bundle: bundle_resource.to_json, endpoint_availability_success_rate: 'all')
 
       expect(result.result).to eq('pass'), %(
         Expected a valid inputted service base url Bundle to pass
@@ -181,10 +182,57 @@ RSpec.describe ServiceBaseURLTestKit::ServiceBaseURLGroup do
         .with(query: hash_including({}))
         .to_return(status: 200, body: validator_response_success.to_json)
 
-      result = run(test, service_base_url_list_url:, endpoint_availability_limit: 2)
+      result = run(test, service_base_url_list_url:, endpoint_availability_success_rate: 'all',
+                         endpoint_availability_limit: 2)
 
       expect(result.result).to eq('pass')
       expect(capability_statement_request_success).to have_been_made.times(2)
+      expect(validation_request).to have_been_made.times(7)
+    end
+
+    it 'passes if at least 1 endpoint is available when success rate input is set to at least 1' do
+      bundle_resource.entry[4].resource.address = "#{base_url}/fake/address/3"
+      bundle_resource.entry[0].resource.address = "#{base_url}/fake/address/1"
+
+      stub_request(:get, service_base_url_list_url)
+        .to_return(status: 200, body: bundle_resource.to_json, headers: {})
+
+      fake_uri_template = Addressable::Template.new "#{base_url}/fake/address/{id}/metadata"
+      capability_statement_request_fail = stub_request(:get, fake_uri_template)
+        .to_return(status: 404, body: '', headers: {})
+
+      uri_template = Addressable::Template.new "#{base_url}/{id}/metadata"
+      capability_statement_request_success = stub_request(:get, uri_template)
+        .to_return(status: 200, body: capability_statement.to_json, headers: {})
+
+      validation_request = stub_request(:post, "#{validator_url}/validate")
+        .with(query: hash_including({}))
+        .to_return(status: 200, body: validator_response_success.to_json)
+
+      result = run(test, service_base_url_list_url:, endpoint_availability_success_rate: 'at_least_1')
+
+      expect(result.result).to eq('pass')
+      expect(capability_statement_request_fail).to have_been_made.times(2)
+      expect(capability_statement_request_success).to have_been_made
+      expect(validation_request).to have_been_made.times(7)
+    end
+
+    it 'passes and does not retrieve any capability statements if success rate input set to none' do
+      stub_request(:get, service_base_url_list_url)
+        .to_return(status: 200, body: bundle_resource.to_json, headers: {})
+
+      uri_template = Addressable::Template.new "#{base_url}/{id}/metadata"
+      capability_statement_request_success = stub_request(:get, uri_template)
+        .to_return(status: 200, body: capability_statement.to_json, headers: {})
+
+      validation_request = stub_request(:post, "#{validator_url}/validate")
+        .with(query: hash_including({}))
+        .to_return(status: 200, body: validator_response_success.to_json)
+
+      result = run(test, service_base_url_list_url:, endpoint_availability_success_rate: 'none')
+
+      expect(result.result).to eq('pass')
+      expect(capability_statement_request_success).to have_been_made.times(0)
       expect(validation_request).to have_been_made.times(7)
     end
 


### PR DESCRIPTION
# Summary

Allow for some endpoints to fail the /metadata request without failing the whole system.  Some endpoint lists have so many endpoints that at any given time some might be down because they have been decommissioned since the list was published, and that isn't a sign of nonconformance on the publishers part. This PR adds an input that allows the user to select between 3 options for testing endpoint availability:

- All endpoints that are tested need to be available to pass
- At least 1 endpoint that is tested needs to be available to pass
- No endpoints that are tested need to be available to pass


