### PR TITLE
FI-3036 Fix minor typo in readme and suite description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ for additional guidance.
 This Test Kit is provided as a tool to help developers identify potential issues
 or problems with the structure of their Service Base URL publication.  Test
 failures do not necessarily indicate non-conformance to the Conditions and
-Maintenance of Certification.  Use of these tests is not required. Please
-provide feedback on these tests by reporting an issue in
+Maintenance of Certification.  Use of these tests is not required for the
+participants of the ONC Health IT Certification Program. Please provide feedback
+on these tests by reporting an issue in
 [GitHub](https://github.com/inferno-framework/service-base-url-test-kit/issues),
 or by reaching out to the team on the [Inferno FHIR Zulip
 channel](https://chat.fhir.org/#narrow/stream/179309-inferno).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The **Service Base URL Test Kit** provides a set of tests that verify
 conformance of Service Base URL publications to data format requirements as
-described in [Conditions of Maintenance of Certification - Application
+described in [Conditions and Maintenance of Certification - Application
 programming
 interfaces](https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-D/part-170/subpart-D/section-170.404#p-170.404(b)(2))
 and the [ONC HTI-1 Final
@@ -13,14 +13,14 @@ for additional guidance.
 
 This Test Kit is provided as a tool to help developers identify potential issues
 or problems with the structure of their Service Base URL publication.  Test
-failures do not necessarily indicate non-conformance to the Conditions of
+failures do not necessarily indicate non-conformance to the Conditions and
 Maintenance of Certification.  Use of these tests is not required. Please
 provide feedback on these tests by reporting an issue in
 [GitHub](https://github.com/inferno-framework/service-base-url-test-kit/issues),
 or by reaching out to the team on the [Inferno FHIR Zulip
 channel](https://chat.fhir.org/#narrow/stream/179309-inferno).
 
-Relevant requirements from the [Conditions of Maintenance of Certification -
+Relevant requirements from the [Conditions and Maintenance of Certification -
 Application programming interfaces](https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-D/part-170/subpart-D/section-170.404#p-170.404(b)(2)):
 
 > Service Base URL publication:

--- a/lib/service_base_url_test_kit.rb
+++ b/lib/service_base_url_test_kit.rb
@@ -9,7 +9,7 @@ module ServiceBaseURLTestKit
     description %(
       This Test Kit provides a set of tests that verify conformance of Service
       Base URL publications to data format requirements as described in
-      [Conditions of Maintenance of Certification - Application programming
+      [Conditions and Maintenance of Certification - Application programming
       interfaces](https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-D/part-170/subpart-D/section-170.404#p-170.404(b)(2))
       and the [ONC HTI-1 Final
       Rule](https://www.healthit.gov/topic/laws-regulation-and-policy/health-data-technology-and-interoperability-certification-program).
@@ -19,14 +19,14 @@ module ServiceBaseURLTestKit
 
       This Test Kit is provided as a tool to help developers identify potential issues
       or problems with the structure of their Service Base URL publication.  Test
-      failures do not necessarily indicate non-conformance to the Conditions of
+      failures do not necessarily indicate non-conformance to the Conditions and
       Maintenance of Certification.  Use of these tests is not required.  Please
       provide feedback on these tests by reporting an issue in
       [GitHub](https://github.com/inferno-framework/service-base-url-test-kit/issues),
       or by reaching out to the team on the [Inferno FHIR Zulip
       channel](https://chat.fhir.org/#narrow/stream/179309-inferno).
 
-      Relevant requirements from the Conditions of [Maintenance of Certification -
+      Relevant requirements from the [Conditions and Maintenance of Certification -
       Application programming interfaces](https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-D/part-170/subpart-D/section-170.404#p-170.404(b)(2)):
 
       Service Base URL publication:

--- a/lib/service_base_url_test_kit.rb
+++ b/lib/service_base_url_test_kit.rb
@@ -17,17 +17,19 @@ module ServiceBaseURLTestKit
       Guide](https://www.healthit.gov/condition-ccg/application-programming-interfaces)
       for additional guidance.
 
-      This Test Kit is provided as a tool to help developers identify potential issues
-      or problems with the structure of their Service Base URL publication.  Test
-      failures do not necessarily indicate non-conformance to the Conditions and
-      Maintenance of Certification.  Use of these tests is not required.  Please
-      provide feedback on these tests by reporting an issue in
+      This Test Kit is provided as a tool to help developers identify potential
+      issues or problems with the structure of their Service Base URL
+      publication.  Test failures do not necessarily indicate non-conformance to
+      the Conditions and Maintenance of Certification.  Use of these tests is
+      not required for the participants of the ONC Health IT Certification Program.
+      Please provide feedback on these tests by reporting an issue in
       [GitHub](https://github.com/inferno-framework/service-base-url-test-kit/issues),
       or by reaching out to the team on the [Inferno FHIR Zulip
       channel](https://chat.fhir.org/#narrow/stream/179309-inferno).
-
-      Relevant requirements from the [Conditions and Maintenance of Certification -
-      Application programming interfaces](https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-D/part-170/subpart-D/section-170.404#p-170.404(b)(2)):
+      
+      Relevant requirements from the [Conditions and Maintenance of
+      Certification - Application programming
+      interfaces](https://www.ecfr.gov/current/title-45/subtitle-A/subchapter-D/part-170/subpart-D/section-170.404#p-170.404(b)(2)):
 
       Service Base URL publication:
 


### PR DESCRIPTION
# Summary
Just fixing a minor typo in the suite description and README.  No testing necessary as long as the text looks ok.

It is "Conditions and Maintenance of Certification", not "Conditions of Maintenance of Certification".  Example: https://www.healthit.gov/topic/certification-ehrs/conditions-maintenance-certification

