### PR TITLE
FI-3003 & FI-3004: Add Additional Warning Messages

### DIFF
--- a/lib/service_base_url_test_kit/service_base_url_validate_group.rb
+++ b/lib/service_base_url_test_kit/service_base_url_validate_group.rb
@@ -112,6 +112,17 @@ module ServiceBaseURLTestKit
             The given Bundle does not contain any resources
           )
         end
+
+        additional_resources = bundle_resource.entry
+          .map { |entry| entry.resource.resourceType }
+          .reject { |resource_type| ['Organization', 'Endpoint'].include?(resource_type) }
+          .uniq
+
+        warning do
+          assert(additional_resources.empty?, %(
+          The Service Base URL List contained the following additional resources other than Endpoint and
+          Organization resources: #{additional_resources.join(', ')}))
+        end
       end
     end
 
@@ -293,6 +304,13 @@ module ServiceBaseURLTestKit
           .entry
           .map(&:resource)
           .select { |resource| resource.resourceType == 'Organization' }
+
+        warning do
+          # This was requested to be included because a publication with only a single organization
+          # seems like a likely error and should be checked manually.
+          assert(organization_resources.length > 1,
+                 'The provided Service Base URL List contains only 1 Organization resource')
+        end
 
         organization_resources.each do |organization|
           assert !organization.endpoint.empty?,


### PR DESCRIPTION
# Summary
Add checks in Service Base URL Tests to check if the Bundle contains additional resources other than Endpoint or Organization, and to check if the Bundle only contains a single Organization. The valid Bundle test checks the Bundle to see if there are any extra resource types included, and provides a warning message with the additional resource types included. The valid Organization test produces a warning message if there is only a single Organization.

# Testing Guidance
Run locally and update the Service Base URL Bundle to have extra resources or only a single Organization and ensure the tests produce warning messages

Note: This is a repeat branch of FI-3003-3004_Add_Additional_Warnings, which got overwritten during rebasing